### PR TITLE
42 fix getbusydays Closes #42

### DIFF
--- a/src/meetings/application/getBusyDays/findBusyDays.dao.ts
+++ b/src/meetings/application/getBusyDays/findBusyDays.dao.ts
@@ -12,4 +12,13 @@ export class FindBusyDaysDAO {
   })
   @IsNumberString({no_symbols: true})
   month?: number;
+
+  @ApiProperty({
+    type: Number,
+    description: 'número referente ao ano requisitado',
+    example: 2024,
+    nullable: true,
+  })
+  @IsNumberString({no_symbols: true})
+  year?: number;
 }

--- a/src/meetings/application/getBusyDays/get-busy-days.spec.ts
+++ b/src/meetings/application/getBusyDays/get-busy-days.spec.ts
@@ -27,20 +27,22 @@ describe('getBusyDays', () => {
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
-      getOne: jest.fn()
+      getOne: jest.fn(),
+      getCount: jest.fn(),
     } as any;
   });
 
   it('should return array of busy days when meetings exist', async () => {
-    mockQueryBuilder.getOne.mockResolvedValueOnce({ id: 1 });
+    mockQueryBuilder.getCount.mockResolvedValueOnce(3);
 
     for (let i = 0; i < 30; i++) {
-      mockQueryBuilder.getOne.mockResolvedValueOnce(null);
+      mockQueryBuilder.getCount.mockResolvedValueOnce(0);
     }
 
     const search: FindBusyDaysDAO = {
       psychologistId: '1',
-      month: 1
+      month: 1,
+      year: 2023
     };
 
     const result = await getBusyDays(search, mockRepository);
@@ -52,12 +54,13 @@ describe('getBusyDays', () => {
 
   it('should return all days as not busy when no meetings exist', async () => {
     for (let i = 0; i < 31; i++) {
-      mockQueryBuilder.getOne.mockResolvedValueOnce(null);
+      mockQueryBuilder.getCount.mockResolvedValueOnce(0);
     }
 
     const search: FindBusyDaysDAO = {
       psychologistId: '1',
-      month: 1
+      month: 1,
+      year: 2023
     };
 
     const result = await getBusyDays(search, mockRepository);
@@ -69,11 +72,12 @@ describe('getBusyDays', () => {
   });
 
   it('should call repository with correct parameters', async () => {
-    mockQueryBuilder.getOne.mockResolvedValue(null);
+    mockQueryBuilder.getCount.mockResolvedValue(0);
 
     const search: FindBusyDaysDAO = {
       psychologistId: '2',
-      month: 3
+      month: 3,
+      year: 2023
     };
 
     await getBusyDays(search, mockRepository);
@@ -86,6 +90,10 @@ describe('getBusyDays', () => {
     expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
       'EXTRACT(MONTH FROM meeting._schedule) = :month',
       { month: 3 }
+    );
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'EXTRACT(YEAR FROM meeting._schedule) = :year',
+      { year: 2023 }
     );
   });
 }); 

--- a/src/meetings/application/getBusyDays/get-busy-days.ts
+++ b/src/meetings/application/getBusyDays/get-busy-days.ts
@@ -7,14 +7,16 @@ export interface visualizer {
 }
 export async function getBusyDays(search: FindBusyDaysDAO, repository: Repository<Meeting>) {
   let busyDays: visualizer[] = [];
-  for (let i = 1; i <= 31; i++) {
+  const querybuilder =  repository.createQueryBuilder("meeting");
+  for (let i = 1; i <= daysInMonth(search.month, search.year); i++) {
     let existsSession = false;
-    const day = await repository.createQueryBuilder("meeting")
+    const day = await querybuilder
       .where("meeting.Psychologist_id = :psychologistId", { psychologistId: search.psychologistId })
+      .andWhere("EXTRACT(YEAR FROM meeting._schedule) = :year", { year: search.year })
       .andWhere("EXTRACT(MONTH FROM meeting._schedule) = :month", { month: search.month })
       .andWhere("EXTRACT(DAY FROM meeting._schedule) = :day", { day: i })
-      .getOne();
-    if (day) {
+      .getCount();
+    if (day > 0) {
       existsSession = true;
     }
     busyDays.push({ day: i, existsSession });
@@ -23,3 +25,6 @@ export async function getBusyDays(search: FindBusyDaysDAO, repository: Repositor
   return busyDays;
 }
 
+function daysInMonth (month: number, year: number): number {
+  return new Date(year, month, 0).getDate();
+}

--- a/src/meetings/infra/meetings.controller.ts
+++ b/src/meetings/infra/meetings.controller.ts
@@ -35,10 +35,10 @@ export class MeetingsController {
   @ApiOperation({ summary: 'retorna todos os dias cheios e vazios do mês selecionado' })
   @Get('/busydays')
   async getAllBusyDays(@User() userInfo, @Query() search: FindBusyDaysDAO) {
-    return await this.meetingsService.getBusyDays(
-      userInfo.id,
-      search.month
-    );
+    search.psychologistId = userInfo.id;
+    search.month = search.month ?? new Date().getMonth();
+    search.year = search.year ?? new Date().getFullYear();
+    return await this.meetingsService.getBusyDays(search);
   }
 
   @ApiOperation({ summary: 'retorna os horários disponiveis de um dia específico' })

--- a/src/meetings/infra/meetings.service.ts
+++ b/src/meetings/infra/meetings.service.ts
@@ -19,6 +19,7 @@ import { FrequencyEnum } from './dto/frequency.enum';
 import { numberToDay } from '../../psychologists/vo/days.enum';
 import { checkAvaliableTime } from '../application/checkAvaliableTime/check-avaliable-time';
 import { DocumentsService } from '../../documents/documents.service';
+import { FindBusyDaysDAO } from '../application/getBusyDays/findBusyDays.dao';
 
 @Injectable()
 export class MeetingsService {
@@ -51,11 +52,8 @@ export class MeetingsService {
     }
   }
 
-  async getBusyDays(psychologistId: string, month?: number) {
-    return await getBusyDays({
-      psychologistId,
-      month: month ?? new Date().getMonth(),
-    }, this.meetingsRepository);
+  async getBusyDays(search: FindBusyDaysDAO) {
+    return await getBusyDays(search, this.meetingsRepository);
   }
 
   async AvaliableTimes(psychologistId: string, startDate: Date) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/680374b3-0250-4d72-8aa6-d7a266606119)
agora ano faz parte da busca mensal;

acrescentei uma lógica para pegar o número de dia no mês para iterar o for ( antes ele sempre retornava 31 itens independente do mês)